### PR TITLE
Make completionTokens optionals for embeddings

### DIFF
--- a/Sources/CleverBird/chat/ChatCompletionResponse.swift
+++ b/Sources/CleverBird/chat/ChatCompletionResponse.swift
@@ -4,7 +4,7 @@ import Foundation
 
 public struct Usage: Codable {
     public let promptTokens: Int
-    public let completionTokens: Int
+    public let completionTokens: Int?
     public let totalTokens: Int
 }
 


### PR DESCRIPTION
Embeddings don't return completion tokens in Usage. Making the completion tokens property optional so embedding calls don't fail